### PR TITLE
‘get_week_day()’ First PR

### DIFF
--- a/Calendar_CLI/Calendar.py
+++ b/Calendar_CLI/Calendar.py
@@ -1,0 +1,17 @@
+import datetime
+
+def get_week_of_day(year: int, month: int, day: int) -> int:
+    """
+    Return what week the date is with the year. Every 1/1 to 1/7 of the year will be considered as week 1.
+    args:
+        year: postive integer(AD only)
+        month: from 1 to 12
+        day: from 1 to 31(with exception of Feb)
+    """
+    date = datetime.date(year, month, day)
+    first_day_of_year = datetime.date(year, 1, 1)
+
+    # Calculate the number of days between the provided date and the first day of the year
+    delta = date - first_day_of_year
+    week_number = delta.days // 7 + 1
+    return week_number

--- a/Calendar_CLI/Calendar.py
+++ b/Calendar_CLI/Calendar.py
@@ -6,7 +6,7 @@ def get_week_of_day(year: int, month: int, day: int) -> int:
     args:
         year: postive integer(AD only)
         month: from 1 to 12
-        day: from 1 to 31(except for Feb, Apr, June, Sep, Nov)
+        days: depends on month and leap year, from 1 to {28,29,30,31}
     """
     try:
         date = datetime.date(year, month, day)

--- a/Calendar_CLI/Calendar.py
+++ b/Calendar_CLI/Calendar.py
@@ -6,12 +6,16 @@ def get_week_of_day(year: int, month: int, day: int) -> int:
     args:
         year: postive integer(AD only)
         month: from 1 to 12
-        day: from 1 to 31(with exception of Feb)
+        day: from 1 to 31(except for Feb, Apr, June, Sep, Nov)
     """
-    date = datetime.date(year, month, day)
-    first_day_of_year = datetime.date(year, 1, 1)
+    try:
+        date = datetime.date(year, month, day)
+        first_day_of_year = datetime.date(year, 1, 1)
 
-    # Calculate the number of days between the provided date and the first day of the year
-    delta = date - first_day_of_year
-    week_number = delta.days // 7 + 1
-    return week_number
+        # Calculate the number of days between the provided date and the first day of the year
+        delta = date - first_day_of_year
+        week_number = delta.days // 7 + 1
+        return week_number
+    
+    except ValueError:
+        return "Error: Invalid Date "


### PR DESCRIPTION
### **Summary**

- Add: get_week_of_day() 
- Description: It returns what week the date is within the year. Every 1/1 to 1/7 of the year will be considered as week 1.
- Example1: 
    - Input: 2020, 1, 1
    - Output: 1
- Example2: 
    - Input: 2021, 12, 8
    - Output: 49

