### PR TITLE
`get_week_day()` Second PR

### DIFF
--- a/Calendar_CLI/Calendar.py
+++ b/Calendar_CLI/Calendar.py
@@ -8,7 +8,7 @@ Date: 20230626
 """
 import datetime
 
-def get_week_of_day(year: int, month: int, day: int) -> int:
+def get_week_of_day(year: int, month: int, day: int) -> int():
     """
     Return what week the date is with the year. Every 1/1 to 1/7 of the year will be considered as week 1.
     args:


### PR DESCRIPTION
#9  
### **Summary:**

Fix the bug by adding() after return
`def get_week_of_day(year: int, month: int, day: int) -> int():`

